### PR TITLE
Added guard close for pagination with few results

### DIFF
--- a/completed/ingredients/client.js
+++ b/completed/ingredients/client.js
@@ -58,6 +58,12 @@ function populateResult(elId, results, templateFn) {
 const prev = document.getElementById("prev-button");
 const next = document.getElementById("next-button");
 function togglePaginationButtons(page, count) {
+  if (count <= 5) {
+    prev.setAttribute("disabled", "");
+    next.setAttribute("disabled", "");
+    return;
+  }
+
   if (page === 0) {
     prev.setAttribute("disabled", "");
     next.removeAttribute("disabled");

--- a/ingredients/client.js
+++ b/ingredients/client.js
@@ -54,6 +54,12 @@ function populateResult(elId, results, templateFn) {
 const prev = document.getElementById("prev-button");
 const next = document.getElementById("next-button");
 function togglePaginationButtons(page, count) {
+  if (count <= 5) {
+    prev.setAttribute("disabled", "");
+    next.setAttribute("disabled", "");
+    return;
+  }
+  
   if (page === 0) {
     prev.setAttribute("disabled", "");
     next.removeAttribute("disabled");


### PR DESCRIPTION
While taking the course and working through the first ingredients activity, I got a bit confused a few times when the forward pagination button was still active when there were zero/just a single page's results.

Suggesting a simple guard clause (to keep code as similar as possible to pre-pull-request approach) to disable both pagination buttons when return results will be only a single page's worth.